### PR TITLE
Update vendor js files to Phoenix 1.2 versions

### DIFF
--- a/vendor/phoenix-stub.js
+++ b/vendor/phoenix-stub.js
@@ -1,56 +1,24 @@
 define('phoenix', ['exports'], function(exports) {
-  'use strict';
+  "use strict";
 
-  Object.defineProperty(exports, '__esModule', {
+  var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+
+  var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+  Object.defineProperty(exports, "__esModule", {
     value: true
   });
 
-  var _typeof = typeof Symbol === 'function' && typeof Symbol.iterator === 'symbol' ? function(obj) {
-    return typeof obj;
-  } : function(obj) {
-    return obj && typeof Symbol === 'function' && obj.constructor === Symbol ? 'symbol' : typeof obj;
-  };
+  function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
 
-  var _createClass = function() {
-    function defineProperties(target, props) {
-      for (var i = 0; i < props.length; i++) {
-        var descriptor = props[i];
-        descriptor.enumerable = descriptor.enumerable || false;
-        descriptor.configurable = true;
-        if ('value' in descriptor) descriptor.writable = true;
-        Object.defineProperty(target, descriptor.key, descriptor);
-      }
-    }
-    return function(Constructor, protoProps, staticProps) {
-      if (protoProps) defineProperties(Constructor.prototype, protoProps);
-      if (staticProps) defineProperties(Constructor, staticProps);
-      return Constructor;
-    };
-  }();
-
-  function _toConsumableArray(arr) {
-    if (Array.isArray(arr)) {
-      for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) {
-        arr2[i] = arr[i];
-      }
-      return arr2;
-    } else {
-      return Array.from(arr);
-    }
-  }
-
-  function _classCallCheck(instance, Constructor) {
-    if (!(instance instanceof Constructor)) {
-      throw new TypeError('Cannot call a class as a function');
-    }
-  }
+  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
   // Phoenix Channels JavaScript client
   //
   // ## Socket Connection
   //
   // A single connection is established to the server and
-  // channels are mulitplexed over the connection.
+  // channels are multiplexed over the connection.
   // Connect to the server using the `Socket` class:
   //
   //     let socket = new Socket("/ws", {params: {userToken: "123"}})
@@ -70,7 +38,7 @@ define('phoenix', ['exports'], function(exports) {
   // events are listened for, messages are pushed to the server, and
   // the channel is joined with ok/error/timeout matches:
   //
-  //     let channel = socket.channel("rooms:123", {token: roomToken})
+  //     let channel = socket.channel("room:123", {token: roomToken})
   //     channel.on("new_msg", msg => console.log("Got message", msg) )
   //     $input.onEnter( e => {
   //       channel.push("new_msg", {body: e.target.val}, 10000)
@@ -93,6 +61,15 @@ define('phoenix', ['exports'], function(exports) {
   // Successful joins receive an "ok" status, while unsuccessful joins
   // receive "error".
   //
+  // ## Duplicate Join Subscriptions
+  //
+  // While the client may join any number of topics on any number of channels,
+  // the client may only hold a single subscription for each unique topic at any
+  // given time. When attempting to create a duplicate subscription,
+  // the server will close the existing channel, log a warning, and
+  // spawn a new channel for the topic. The client will have their
+  // `channel.onClose` callbacks fired for the existing channel, and the new
+  // channel join will have its receive hooks processed as normal.
   //
   // ## Pushing Messages
   //
@@ -123,7 +100,7 @@ define('phoenix', ['exports'], function(exports) {
   // ### onError hooks
   //
   // `onError` hooks are invoked if the socket connection drops, or the channel
-  // crashes on the server. In either case, a channel rejoin is attemtped
+  // crashes on the server. In either case, a channel rejoin is attempted
   // automatically in an exponential backoff manner.
   //
   // ### onClose hooks
@@ -165,7 +142,7 @@ define('phoenix', ['exports'], function(exports) {
   // they came online from:
   //
   //     let state = {}
-  //     Presence.syncState(state, stateFromServer)
+  //     state = Presence.syncState(state, stateFromServer)
   //     let listBy = (id, {metas: [first, ...rest]}) => {
   //       first.count = rest.length + 1 // count of this user's presences
   //       first.id = id
@@ -195,42 +172,38 @@ define('phoenix', ['exports'], function(exports) {
   //     let presences = {} // client's initial empty presence state
   //     // receive initial presence data from server, sent after join
   //     myChannel.on("presences", state => {
-  //       Presence.syncState(presences, state, onJoin, onLeave)
+  //       presences = Presence.syncState(presences, state, onJoin, onLeave)
   //       displayUsers(Presence.list(presences))
   //     })
   //     // receive "presence_diff" from server, containing join/leave events
   //     myChannel.on("presence_diff", diff => {
-  //       Presence.syncDiff(presences, diff, onJoin, onLeave)
+  //       presences = Presence.syncDiff(presences, diff, onJoin, onLeave)
   //       this.setState({users: Presence.list(room.presences, listBy)})
   //     })
   //
-  var VSN = '1.0.0';
-  var SOCKET_STATES = {
-    connecting: 0,
-    open: 1,
-    closing: 2,
-    closed: 3
-  };
+  var VSN = "1.0.0";
+  var SOCKET_STATES = { connecting: 0, open: 1, closing: 2, closed: 3 };
   var DEFAULT_TIMEOUT = 10000;
   var CHANNEL_STATES = {
-    closed: 'closed',
-    errored: 'errored',
-    joined: 'joined',
-    joining: 'joining'
+    closed: "closed",
+    errored: "errored",
+    joined: "joined",
+    joining: "joining",
+    leaving: "leaving"
   };
   var CHANNEL_EVENTS = {
-    close: 'phx_close',
-    error: 'phx_error',
-    join: 'phx_join',
-    reply: 'phx_reply',
-    leave: 'phx_leave'
+    close: "phx_close",
+    error: "phx_error",
+    join: "phx_join",
+    reply: "phx_reply",
+    leave: "phx_leave"
   };
   var TRANSPORTS = {
-    longpoll: 'longpoll',
-    websocket: 'websocket'
+    longpoll: "longpoll",
+    websocket: "websocket"
   };
 
-  var Push = function() {
+  var Push = function () {
 
     // Initializes the Push
     //
@@ -254,7 +227,7 @@ define('phoenix', ['exports'], function(exports) {
     }
 
     _createClass(Push, [{
-      key: 'resend',
+      key: "resend",
       value: function resend(timeout) {
         this.timeout = timeout;
         this.cancelRefEvent();
@@ -265,9 +238,9 @@ define('phoenix', ['exports'], function(exports) {
         this.send();
       }
     }, {
-      key: 'send',
+      key: "send",
       value: function send() {
-        if (this.hasReceived('timeout')) {
+        if (this.hasReceived("timeout")) {
           return;
         }
         this.startTimeout();
@@ -280,36 +253,33 @@ define('phoenix', ['exports'], function(exports) {
         });
       }
     }, {
-      key: 'receive',
+      key: "receive",
       value: function receive(status, callback) {
         if (this.hasReceived(status)) {
           callback(this.receivedResp.response);
         }
 
-        this.recHooks.push({
-          status: status,
-          callback: callback
-        });
+        this.recHooks.push({ status: status, callback: callback });
         return this;
       }
 
       // private
 
     }, {
-      key: 'matchReceive',
+      key: "matchReceive",
       value: function matchReceive(_ref) {
         var status = _ref.status;
         var response = _ref.response;
         var ref = _ref.ref;
 
-        this.recHooks.filter(function(h) {
+        this.recHooks.filter(function (h) {
           return h.status === status;
-        }).forEach(function(h) {
+        }).forEach(function (h) {
           return h.callback(response);
         });
       }
     }, {
-      key: 'cancelRefEvent',
+      key: "cancelRefEvent",
       value: function cancelRefEvent() {
         if (!this.refEvent) {
           return;
@@ -317,13 +287,13 @@ define('phoenix', ['exports'], function(exports) {
         this.channel.off(this.refEvent);
       }
     }, {
-      key: 'cancelTimeout',
+      key: "cancelTimeout",
       value: function cancelTimeout() {
         clearTimeout(this.timeoutTimer);
         this.timeoutTimer = null;
       }
     }, {
-      key: 'startTimeout',
+      key: "startTimeout",
       value: function startTimeout() {
         var _this = this;
 
@@ -333,36 +303,33 @@ define('phoenix', ['exports'], function(exports) {
         this.ref = this.channel.socket.makeRef();
         this.refEvent = this.channel.replyEventName(this.ref);
 
-        this.channel.on(this.refEvent, function(payload) {
+        this.channel.on(this.refEvent, function (payload) {
           _this.cancelRefEvent();
           _this.cancelTimeout();
           _this.receivedResp = payload;
           _this.matchReceive(payload);
         });
 
-        this.timeoutTimer = setTimeout(function() {
-          _this.trigger('timeout', {});
+        this.timeoutTimer = setTimeout(function () {
+          _this.trigger("timeout", {});
         }, this.timeout);
       }
     }, {
-      key: 'hasReceived',
+      key: "hasReceived",
       value: function hasReceived(status) {
         return this.receivedResp && this.receivedResp.status === status;
       }
     }, {
-      key: 'trigger',
+      key: "trigger",
       value: function trigger(status, response) {
-        this.channel.trigger(this.refEvent, {
-          status: status,
-          response: response
-        });
+        this.channel.trigger(this.refEvent, { status: status, response: response });
       }
     }]);
 
     return Push;
   }();
 
-  var Channel = exports.Channel = function() {
+  var Channel = exports.Channel = function () {
     function Channel(topic, params, socket) {
       var _this2 = this;
 
@@ -377,43 +344,46 @@ define('phoenix', ['exports'], function(exports) {
       this.joinedOnce = false;
       this.joinPush = new Push(this, CHANNEL_EVENTS.join, this.params, this.timeout);
       this.pushBuffer = [];
-      this.rejoinTimer = new Timer(function() {
+      this.rejoinTimer = new Timer(function () {
         return _this2.rejoinUntilConnected();
       }, this.socket.reconnectAfterMs);
-      this.joinPush.receive('ok', function() {
+      this.joinPush.receive("ok", function () {
         _this2.state = CHANNEL_STATES.joined;
         _this2.rejoinTimer.reset();
-        _this2.pushBuffer.forEach(function(pushEvent) {
+        _this2.pushBuffer.forEach(function (pushEvent) {
           return pushEvent.send();
         });
         _this2.pushBuffer = [];
       });
-      this.onClose(function() {
-        _this2.socket.log('channel', 'close ' + _this2.topic);
+      this.onClose(function () {
+        _this2.rejoinTimer.reset();
+        _this2.socket.log("channel", "close " + _this2.topic + " " + _this2.joinRef());
         _this2.state = CHANNEL_STATES.closed;
         _this2.socket.remove(_this2);
       });
-      this.onError(function(reason) {
-        _this2.socket.log('channel', 'error ' + _this2.topic, reason);
-        _this2.state = CHANNEL_STATES.errored;
-        _this2.rejoinTimer.scheduleTimeout();
-      });
-      this.joinPush.receive('timeout', function() {
-        if (_this2.state !== CHANNEL_STATES.joining) {
+      this.onError(function (reason) {
+        if (_this2.isLeaving() || _this2.isClosed()) {
           return;
         }
-
-        _this2.socket.log('channel', 'timeout ' + _this2.topic, _this2.joinPush.timeout);
+        _this2.socket.log("channel", "error " + _this2.topic, reason);
         _this2.state = CHANNEL_STATES.errored;
         _this2.rejoinTimer.scheduleTimeout();
       });
-      this.on(CHANNEL_EVENTS.reply, function(payload, ref) {
+      this.joinPush.receive("timeout", function () {
+        if (!_this2.isJoining()) {
+          return;
+        }
+        _this2.socket.log("channel", "timeout " + _this2.topic, _this2.joinPush.timeout);
+        _this2.state = CHANNEL_STATES.errored;
+        _this2.rejoinTimer.scheduleTimeout();
+      });
+      this.on(CHANNEL_EVENTS.reply, function (payload, ref) {
         _this2.trigger(_this2.replyEventName(ref), payload);
       });
     }
 
     _createClass(Channel, [{
-      key: 'rejoinUntilConnected',
+      key: "rejoinUntilConnected",
       value: function rejoinUntilConnected() {
         this.rejoinTimer.scheduleTimeout();
         if (this.socket.isConnected()) {
@@ -421,7 +391,7 @@ define('phoenix', ['exports'], function(exports) {
         }
       }
     }, {
-      key: 'join',
+      key: "join",
       value: function join() {
         var timeout = arguments.length <= 0 || arguments[0] === undefined ? this.timeout : arguments[0];
 
@@ -429,44 +399,41 @@ define('phoenix', ['exports'], function(exports) {
           throw "tried to join multiple times. 'join' can only be called a single time per channel instance";
         } else {
           this.joinedOnce = true;
+          this.rejoin(timeout);
+          return this.joinPush;
         }
-        this.rejoin(timeout);
-        return this.joinPush;
       }
     }, {
-      key: 'onClose',
+      key: "onClose",
       value: function onClose(callback) {
         this.on(CHANNEL_EVENTS.close, callback);
       }
     }, {
-      key: 'onError',
+      key: "onError",
       value: function onError(callback) {
-        this.on(CHANNEL_EVENTS.error, function(reason) {
+        this.on(CHANNEL_EVENTS.error, function (reason) {
           return callback(reason);
         });
       }
     }, {
-      key: 'on',
+      key: "on",
       value: function on(event, callback) {
-        this.bindings.push({
-          event: event,
-          callback: callback
-        });
+        this.bindings.push({ event: event, callback: callback });
       }
     }, {
-      key: 'off',
+      key: "off",
       value: function off(event) {
-        this.bindings = this.bindings.filter(function(bind) {
+        this.bindings = this.bindings.filter(function (bind) {
           return bind.event !== event;
         });
       }
     }, {
-      key: 'canPush',
+      key: "canPush",
       value: function canPush() {
-        return this.socket.isConnected() && this.state === CHANNEL_STATES.joined;
+        return this.socket.isConnected() && this.isJoined();
       }
     }, {
-      key: 'push',
+      key: "push",
       value: function push(event, payload) {
         var timeout = arguments.length <= 2 || arguments[2] === undefined ? this.timeout : arguments[2];
 
@@ -498,25 +465,26 @@ define('phoenix', ['exports'], function(exports) {
       //
 
     }, {
-      key: 'leave',
+      key: "leave",
       value: function leave() {
         var _this3 = this;
 
         var timeout = arguments.length <= 0 || arguments[0] === undefined ? this.timeout : arguments[0];
 
+        this.state = CHANNEL_STATES.leaving;
         var onClose = function onClose() {
-          _this3.socket.log('channel', 'leave ' + _this3.topic);
-          _this3.trigger(CHANNEL_EVENTS.close, 'leave');
+          _this3.socket.log("channel", "leave " + _this3.topic);
+          _this3.trigger(CHANNEL_EVENTS.close, "leave", _this3.joinRef());
         };
         var leavePush = new Push(this, CHANNEL_EVENTS.leave, {}, timeout);
-        leavePush.receive('ok', function() {
+        leavePush.receive("ok", function () {
           return onClose();
-        }).receive('timeout', function() {
+        }).receive("timeout", function () {
           return onClose();
         });
         leavePush.send();
         if (!this.canPush()) {
-          leavePush.trigger('ok', {});
+          leavePush.trigger("ok", {});
         }
 
         return leavePush;
@@ -525,51 +493,101 @@ define('phoenix', ['exports'], function(exports) {
       // Overridable message hook
       //
       // Receives all events for specialized message handling
+      // before dispatching to the channel callbacks.
+      //
+      // Must return the payload, modified or unmodified
 
     }, {
-      key: 'onMessage',
-      value: function onMessage(event, payload, ref) {}
+      key: "onMessage",
+      value: function onMessage(event, payload, ref) {
+        return payload;
+      }
 
       // private
 
     }, {
-      key: 'isMember',
+      key: "isMember",
       value: function isMember(topic) {
         return this.topic === topic;
       }
     }, {
-      key: 'sendJoin',
+      key: "joinRef",
+      value: function joinRef() {
+        return this.joinPush.ref;
+      }
+    }, {
+      key: "sendJoin",
       value: function sendJoin(timeout) {
         this.state = CHANNEL_STATES.joining;
         this.joinPush.resend(timeout);
       }
     }, {
-      key: 'rejoin',
+      key: "rejoin",
       value: function rejoin() {
         var timeout = arguments.length <= 0 || arguments[0] === undefined ? this.timeout : arguments[0];
+        if (this.isLeaving()) {
+          return;
+        }
         this.sendJoin(timeout);
       }
     }, {
-      key: 'trigger',
-      value: function trigger(triggerEvent, payload, ref) {
-        this.onMessage(triggerEvent, payload, ref);
-        this.bindings.filter(function(bind) {
-          return bind.event === triggerEvent;
-        }).map(function(bind) {
-          return bind.callback(payload, ref);
+      key: "trigger",
+      value: function trigger(event, payload, ref) {
+        var close = CHANNEL_EVENTS.close;
+        var error = CHANNEL_EVENTS.error;
+        var leave = CHANNEL_EVENTS.leave;
+        var join = CHANNEL_EVENTS.join;
+
+        if (ref && [close, error, leave, join].indexOf(event) >= 0 && ref !== this.joinRef()) {
+          return;
+        }
+        var handledPayload = this.onMessage(event, payload, ref);
+        if (payload && !handledPayload) {
+          throw "channel onMessage callbacks must return the payload, modified or unmodified";
+        }
+
+        this.bindings.filter(function (bind) {
+          return bind.event === event;
+        }).map(function (bind) {
+          return bind.callback(handledPayload, ref);
         });
       }
     }, {
-      key: 'replyEventName',
+      key: "replyEventName",
       value: function replyEventName(ref) {
-        return 'chan_reply_' + ref;
+        return "chan_reply_" + ref;
+      }
+    }, {
+      key: "isClosed",
+      value: function isClosed() {
+        return this.state === CHANNEL_STATES.closed;
+      }
+    }, {
+      key: "isErrored",
+      value: function isErrored() {
+        return this.state === CHANNEL_STATES.errored;
+      }
+    }, {
+      key: "isJoined",
+      value: function isJoined() {
+        return this.state === CHANNEL_STATES.joined;
+      }
+    }, {
+      key: "isJoining",
+      value: function isJoining() {
+        return this.state === CHANNEL_STATES.joining;
+      }
+    }, {
+      key: "isLeaving",
+      value: function isLeaving() {
+        return this.state === CHANNEL_STATES.leaving;
       }
     }]);
 
     return Channel;
   }();
 
-  var Socket = exports.Socket = function() {
+  var Socket = exports.Socket = function () {
 
     // Initializes the Socket
     //
@@ -607,59 +625,52 @@ define('phoenix', ['exports'], function(exports) {
 
       _classCallCheck(this, Socket);
 
-      this.stateChangeCallbacks = {
-        open: [],
-        close: [],
-        error: [],
-        message: []
-      };
+      this.stateChangeCallbacks = { open: [], close: [], error: [], message: [] };
       this.channels = [];
       this.sendBuffer = [];
       this.ref = 0;
       this.timeout = opts.timeout || DEFAULT_TIMEOUT;
       this.transport = opts.transport || window.WebSocket || LongPoll;
       this.heartbeatIntervalMs = opts.heartbeatIntervalMs || 30000;
-      this.reconnectAfterMs = opts.reconnectAfterMs || function(tries) {
-        return [1000, 2000, 5000, 10000][tries - 1] || 10000;
-      };
-      this.logger = opts.logger || function() {}; // noop
+      this.reconnectAfterMs = opts.reconnectAfterMs || function (tries) {
+          return [1000, 2000, 5000, 10000][tries - 1] || 10000;
+        };
+      this.logger = opts.logger || function () {}; // noop
       this.longpollerTimeout = opts.longpollerTimeout || 20000;
       this.params = opts.params || {};
-      this.endPoint = endPoint + '/' + TRANSPORTS.websocket;
-      this.reconnectTimer = new Timer(function() {
-        _this4.disconnect(function() {
+      this.endPoint = endPoint + "/" + TRANSPORTS.websocket;
+      this.reconnectTimer = new Timer(function () {
+        _this4.disconnect(function () {
           return _this4.connect();
         });
       }, this.reconnectAfterMs);
     }
 
     _createClass(Socket, [{
-      key: 'protocol',
+      key: "protocol",
       value: function protocol() {
-        return location.protocol.match(/^https/) ? 'wss' : 'ws';
+        return location.protocol.match(/^https/) ? "wss" : "ws";
       }
     }, {
-      key: 'endPointURL',
+      key: "endPointURL",
       value: function endPointURL() {
-        var uri = Ajax.appendParams(Ajax.appendParams(this.endPoint, this.params), {
-          vsn: VSN
-        });
-        if (uri.charAt(0) !== '/') {
+        var uri = Ajax.appendParams(Ajax.appendParams(this.endPoint, this.params), { vsn: VSN });
+        if (uri.charAt(0) !== "/") {
           return uri;
         }
-        if (uri.charAt(1) === '/') {
-          return this.protocol() + ':' + uri;
+        if (uri.charAt(1) === "/") {
+          return this.protocol() + ":" + uri;
         }
 
-        return this.protocol() + '://' + location.host + uri;
+        return this.protocol() + "://" + location.host + uri;
       }
     }, {
-      key: 'disconnect',
+      key: "disconnect",
       value: function disconnect(callback, code, reason) {
         if (this.conn) {
-          this.conn.onclose = function() {}; // noop
+          this.conn.onclose = function () {}; // noop
           if (code) {
-            this.conn.close(code, reason || '');
+            this.conn.close(code, reason || "");
           } else {
             this.conn.close();
           }
@@ -671,12 +682,12 @@ define('phoenix', ['exports'], function(exports) {
       // params - The params to send when connecting, for example `{user_id: userToken}`
 
     }, {
-      key: 'connect',
+      key: "connect",
       value: function connect(params) {
         var _this5 = this;
 
         if (params) {
-          console && console.log('passing params to connect is deprecated. Instead pass :params to the Socket constructor');
+          console && console.log("passing params to connect is deprecated. Instead pass :params to the Socket constructor");
           this.params = params;
         }
         if (this.conn) {
@@ -685,16 +696,16 @@ define('phoenix', ['exports'], function(exports) {
 
         this.conn = new this.transport(this.endPointURL());
         this.conn.timeout = this.longpollerTimeout;
-        this.conn.onopen = function() {
+        this.conn.onopen = function () {
           return _this5.onConnOpen();
         };
-        this.conn.onerror = function(error) {
+        this.conn.onerror = function (error) {
           return _this5.onConnError(error);
         };
-        this.conn.onmessage = function(event) {
+        this.conn.onmessage = function (event) {
           return _this5.onConnMessage(event);
         };
-        this.conn.onclose = function(event) {
+        this.conn.onclose = function (event) {
           return _this5.onConnClose(event);
         };
       }
@@ -702,7 +713,7 @@ define('phoenix', ['exports'], function(exports) {
       // Logs the message. Override `this.logger` for specialized logging. noops by default
 
     }, {
-      key: 'log',
+      key: "log",
       value: function log(kind, msg, data) {
         this.logger(kind, msg, data);
       }
@@ -715,98 +726,98 @@ define('phoenix', ['exports'], function(exports) {
       //
 
     }, {
-      key: 'onOpen',
+      key: "onOpen",
       value: function onOpen(callback) {
         this.stateChangeCallbacks.open.push(callback);
       }
     }, {
-      key: 'onClose',
+      key: "onClose",
       value: function onClose(callback) {
         this.stateChangeCallbacks.close.push(callback);
       }
     }, {
-      key: 'onError',
+      key: "onError",
       value: function onError(callback) {
         this.stateChangeCallbacks.error.push(callback);
       }
     }, {
-      key: 'onMessage',
+      key: "onMessage",
       value: function onMessage(callback) {
         this.stateChangeCallbacks.message.push(callback);
       }
     }, {
-      key: 'onConnOpen',
+      key: "onConnOpen",
       value: function onConnOpen() {
         var _this6 = this;
 
-        this.log('transport', 'connected to ' + this.endPointURL(), this.transport.prototype);
+        this.log("transport", "connected to " + this.endPointURL(), this.transport.prototype);
         this.flushSendBuffer();
         this.reconnectTimer.reset();
         if (!this.conn.skipHeartbeat) {
           clearInterval(this.heartbeatTimer);
-          this.heartbeatTimer = setInterval(function() {
+          this.heartbeatTimer = setInterval(function () {
             return _this6.sendHeartbeat();
           }, this.heartbeatIntervalMs);
         }
-        this.stateChangeCallbacks.open.forEach(function(callback) {
+        this.stateChangeCallbacks.open.forEach(function (callback) {
           return callback();
         });
       }
     }, {
-      key: 'onConnClose',
+      key: "onConnClose",
       value: function onConnClose(event) {
-        this.log('transport', 'close', event);
+        this.log("transport", "close", event);
         this.triggerChanError();
         clearInterval(this.heartbeatTimer);
         this.reconnectTimer.scheduleTimeout();
-        this.stateChangeCallbacks.close.forEach(function(callback) {
+        this.stateChangeCallbacks.close.forEach(function (callback) {
           return callback(event);
         });
       }
     }, {
-      key: 'onConnError',
+      key: "onConnError",
       value: function onConnError(error) {
-        this.log('transport', error);
+        this.log("transport", error);
         this.triggerChanError();
-        this.stateChangeCallbacks.error.forEach(function(callback) {
+        this.stateChangeCallbacks.error.forEach(function (callback) {
           return callback(error);
         });
       }
     }, {
-      key: 'triggerChanError',
+      key: "triggerChanError",
       value: function triggerChanError() {
-        this.channels.forEach(function(channel) {
+        this.channels.forEach(function (channel) {
           return channel.trigger(CHANNEL_EVENTS.error);
         });
       }
     }, {
-      key: 'connectionState',
+      key: "connectionState",
       value: function connectionState() {
         switch (this.conn && this.conn.readyState) {
           case SOCKET_STATES.connecting:
-            return 'connecting';
+            return "connecting";
           case SOCKET_STATES.open:
-            return 'open';
+            return "open";
           case SOCKET_STATES.closing:
-            return 'closing';
+            return "closing";
           default:
-            return 'closed';
+            return "closed";
         }
       }
     }, {
-      key: 'isConnected',
+      key: "isConnected",
       value: function isConnected() {
-        return this.connectionState() === 'open';
+        return this.connectionState() === "open";
       }
     }, {
-      key: 'remove',
+      key: "remove",
       value: function remove(channel) {
-        this.channels = this.channels.filter(function(c) {
-          return !c.isMember(channel.topic);
+        this.channels = this.channels.filter(function (c) {
+          return c.joinRef() !== channel.joinRef();
         });
       }
     }, {
-      key: 'channel',
+      key: "channel",
       value: function channel(topic) {
         var chanParams = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
 
@@ -815,7 +826,7 @@ define('phoenix', ['exports'], function(exports) {
         return chan;
       }
     }, {
-      key: 'push',
+      key: "push",
       value: function push(data) {
         var _this7 = this;
 
@@ -827,7 +838,7 @@ define('phoenix', ['exports'], function(exports) {
         var callback = function callback() {
           return _this7.conn.send(JSON.stringify(data));
         };
-        this.log('push', topic + ' ' + event + ' (' + ref + ')', payload);
+        this.log("push", topic + " " + event + " (" + ref + ")", payload);
         if (this.isConnected()) {
           callback();
         } else {
@@ -838,7 +849,7 @@ define('phoenix', ['exports'], function(exports) {
       // Return the next message ref, accounting for overflows
 
     }, {
-      key: 'makeRef',
+      key: "makeRef",
       value: function makeRef() {
         var newRef = this.ref + 1;
         if (newRef === this.ref) {
@@ -850,30 +861,25 @@ define('phoenix', ['exports'], function(exports) {
         return this.ref.toString();
       }
     }, {
-      key: 'sendHeartbeat',
+      key: "sendHeartbeat",
       value: function sendHeartbeat() {
         if (!this.isConnected()) {
           return;
         }
-        this.push({
-          topic: 'phoenix',
-          event: 'heartbeat',
-          payload: {},
-          ref: this.makeRef()
-        });
+        this.push({ topic: "phoenix", event: "heartbeat", payload: {}, ref: this.makeRef() });
       }
     }, {
-      key: 'flushSendBuffer',
+      key: "flushSendBuffer",
       value: function flushSendBuffer() {
         if (this.isConnected() && this.sendBuffer.length > 0) {
-          this.sendBuffer.forEach(function(callback) {
+          this.sendBuffer.forEach(function (callback) {
             return callback();
           });
           this.sendBuffer = [];
         }
       }
     }, {
-      key: 'onConnMessage',
+      key: "onConnMessage",
       value: function onConnMessage(rawMessage) {
         var msg = JSON.parse(rawMessage.data);
         var topic = msg.topic;
@@ -881,13 +887,13 @@ define('phoenix', ['exports'], function(exports) {
         var payload = msg.payload;
         var ref = msg.ref;
 
-        this.log('receive', (payload.status || '') + ' ' + topic + ' ' + event + ' ' + (ref && '(' + ref + ')' || ''), payload);
-        this.channels.filter(function(channel) {
+        this.log("receive", (payload.status || "") + " " + topic + " " + event + " " + (ref && "(" + ref + ")" || ""), payload);
+        this.channels.filter(function (channel) {
           return channel.isMember(topic);
-        }).forEach(function(channel) {
+        }).forEach(function (channel) {
           return channel.trigger(event, payload, ref);
         });
-        this.stateChangeCallbacks.message.forEach(function(callback) {
+        this.stateChangeCallbacks.message.forEach(function (callback) {
           return callback(msg);
         });
       }
@@ -896,17 +902,17 @@ define('phoenix', ['exports'], function(exports) {
     return Socket;
   }();
 
-  var LongPoll = exports.LongPoll = function() {
+  var LongPoll = exports.LongPoll = function () {
     function LongPoll(endPoint) {
       _classCallCheck(this, LongPoll);
 
       this.endPoint = null;
       this.token = null;
       this.skipHeartbeat = true;
-      this.onopen = function() {}; // noop
-      this.onerror = function() {}; // noop
-      this.onmessage = function() {}; // noop
-      this.onclose = function() {}; // noop
+      this.onopen = function () {}; // noop
+      this.onerror = function () {}; // noop
+      this.onmessage = function () {}; // noop
+      this.onclose = function () {}; // noop
       this.pollEndpoint = this.normalizeEndpoint(endPoint);
       this.readyState = SOCKET_STATES.connecting;
 
@@ -914,31 +920,29 @@ define('phoenix', ['exports'], function(exports) {
     }
 
     _createClass(LongPoll, [{
-      key: 'normalizeEndpoint',
+      key: "normalizeEndpoint",
       value: function normalizeEndpoint(endPoint) {
-        return endPoint.replace('ws://', 'http://').replace('wss://', 'https://').replace(new RegExp('(.*)\/' + TRANSPORTS.websocket), '$1/' + TRANSPORTS.longpoll);
+        return endPoint.replace("ws://", "http://").replace("wss://", "https://").replace(new RegExp("(.*)\/" + TRANSPORTS.websocket), "$1/" + TRANSPORTS.longpoll);
       }
     }, {
-      key: 'endpointURL',
+      key: "endpointURL",
       value: function endpointURL() {
-        return Ajax.appendParams(this.pollEndpoint, {
-          token: this.token
-        });
+        return Ajax.appendParams(this.pollEndpoint, { token: this.token });
       }
     }, {
-      key: 'closeAndRetry',
+      key: "closeAndRetry",
       value: function closeAndRetry() {
         this.close();
         this.readyState = SOCKET_STATES.connecting;
       }
     }, {
-      key: 'ontimeout',
+      key: "ontimeout",
       value: function ontimeout() {
-        this.onerror('timeout');
+        this.onerror("timeout");
         this.closeAndRetry();
       }
     }, {
-      key: 'poll',
+      key: "poll",
       value: function poll() {
         var _this8 = this;
 
@@ -946,7 +950,7 @@ define('phoenix', ['exports'], function(exports) {
           return;
         }
 
-        Ajax.request('GET', this.endpointURL(), 'application/json', null, this.timeout, this.ontimeout.bind(this), function(resp) {
+        Ajax.request("GET", this.endpointURL(), "application/json", null, this.timeout, this.ontimeout.bind(this), function (resp) {
           if (resp) {
             var status = resp.status;
             var token = resp.token;
@@ -959,10 +963,8 @@ define('phoenix', ['exports'], function(exports) {
 
           switch (status) {
             case 200:
-              messages.forEach(function(msg) {
-                return _this8.onmessage({
-                  data: JSON.stringify(msg)
-                });
+              messages.forEach(function (msg) {
+                return _this8.onmessage({ data: JSON.stringify(msg) });
               });
               _this8.poll();
               break;
@@ -980,16 +982,16 @@ define('phoenix', ['exports'], function(exports) {
               _this8.closeAndRetry();
               break;
             default:
-              throw 'unhandled poll status ' + status;
+              throw "unhandled poll status " + status;
           }
         });
       }
     }, {
-      key: 'send',
+      key: "send",
       value: function send(body) {
         var _this9 = this;
 
-        Ajax.request('POST', this.endpointURL(), 'application/json', body, this.timeout, this.onerror.bind(this, 'timeout'), function(resp) {
+        Ajax.request("POST", this.endpointURL(), "application/json", body, this.timeout, this.onerror.bind(this, "timeout"), function (resp) {
           if (!resp || resp.status !== 200) {
             _this9.onerror(status);
             _this9.closeAndRetry();
@@ -997,7 +999,7 @@ define('phoenix', ['exports'], function(exports) {
         });
       }
     }, {
-      key: 'close',
+      key: "close",
       value: function close(code, reason) {
         this.readyState = SOCKET_STATES.closed;
         this.onclose();
@@ -1007,24 +1009,24 @@ define('phoenix', ['exports'], function(exports) {
     return LongPoll;
   }();
 
-  var Ajax = exports.Ajax = function() {
+  var Ajax = exports.Ajax = function () {
     function Ajax() {
       _classCallCheck(this, Ajax);
     }
 
     _createClass(Ajax, null, [{
-      key: 'request',
+      key: "request",
       value: function request(method, endPoint, accept, body, timeout, ontimeout, callback) {
 
       }
     }, {
-      key: 'xdomainRequest',
+      key: "xdomainRequest",
       value: function xdomainRequest(req, method, endPoint, body, timeout, ontimeout, callback) {
         var _this10 = this;
 
         req.timeout = timeout;
         req.open(method, endPoint);
-        req.onload = function() {
+        req.onload = function () {
           var response = _this10.parseJSON(req.responseText);
           callback && callback(response);
         };
@@ -1033,22 +1035,22 @@ define('phoenix', ['exports'], function(exports) {
         }
 
         // Work around bug in IE9 that requires an attached onprogress handler
-        req.onprogress = function() {};
+        req.onprogress = function () {};
 
         req.send(body);
       }
     }, {
-      key: 'xhrRequest',
+      key: "xhrRequest",
       value: function xhrRequest(req, method, endPoint, accept, body, timeout, ontimeout, callback) {
         var _this11 = this;
 
         req.timeout = timeout;
         req.open(method, endPoint, true);
-        req.setRequestHeader('Content-Type', accept);
-        req.onerror = function() {
+        req.setRequestHeader("Content-Type", accept);
+        req.onerror = function () {
           callback && callback(null);
         };
-        req.onreadystatechange = function() {
+        req.onreadystatechange = function () {
           if (req.readyState === _this11.states.complete && callback) {
             var response = _this11.parseJSON(req.responseText);
             callback(response);
@@ -1061,73 +1063,72 @@ define('phoenix', ['exports'], function(exports) {
         req.send(body);
       }
     }, {
-      key: 'parseJSON',
+      key: "parseJSON",
       value: function parseJSON(resp) {
-        return resp && resp !== '' ? JSON.parse(resp) : null;
+        return resp && resp !== "" ? JSON.parse(resp) : null;
       }
     }, {
-      key: 'serialize',
+      key: "serialize",
       value: function serialize(obj, parentKey) {
         var queryStr = [];
         for (var key in obj) {
           if (!obj.hasOwnProperty(key)) {
             continue;
           }
-          var paramKey = parentKey ? parentKey + '[' + key + ']' : key;
+          var paramKey = parentKey ? parentKey + "[" + key + "]" : key;
           var paramVal = obj[key];
-          if ((typeof paramVal === 'undefined' ? 'undefined' : _typeof(paramVal)) === 'object') {
+          if ((typeof paramVal === "undefined" ? "undefined" : _typeof(paramVal)) === "object") {
             queryStr.push(this.serialize(paramVal, paramKey));
           } else {
-            queryStr.push(encodeURIComponent(paramKey) + '=' + encodeURIComponent(paramVal));
+            queryStr.push(encodeURIComponent(paramKey) + "=" + encodeURIComponent(paramVal));
           }
         }
-        return queryStr.join('&');
+        return queryStr.join("&");
       }
     }, {
-      key: 'appendParams',
+      key: "appendParams",
       value: function appendParams(url, params) {
         if (Object.keys(params).length === 0) {
           return url;
         }
 
-        var prefix = url.match(/\?/) ? '&' : '?';
-        return '' + url + prefix + this.serialize(params);
+        var prefix = url.match(/\?/) ? "&" : "?";
+        return "" + url + prefix + this.serialize(params);
       }
     }]);
 
     return Ajax;
   }();
 
-  Ajax.states = {
-    complete: 4
-  };
+  Ajax.states = { complete: 4 };
 
   var Presence = exports.Presence = {
-    syncState: function syncState(state, newState, onJoin, onLeave) {
+    syncState: function syncState(currentState, newState, onJoin, onLeave) {
       var _this12 = this;
 
+      var state = this.clone(currentState);
       var joins = {};
       var leaves = {};
 
-      this.map(state, function(key, presence) {
+      this.map(state, function (key, presence) {
         if (!newState[key]) {
-          leaves[key] = _this12.clone(presence);
+          leaves[key] = presence;
         }
       });
-      this.map(newState, function(key, newPresence) {
+      this.map(newState, function (key, newPresence) {
         var currentPresence = state[key];
         if (currentPresence) {
-          (function() {
-            var newRefs = newPresence.metas.map(function(m) {
+          (function () {
+            var newRefs = newPresence.metas.map(function (m) {
               return m.phx_ref;
             });
-            var curRefs = currentPresence.metas.map(function(m) {
+            var curRefs = currentPresence.metas.map(function (m) {
               return m.phx_ref;
             });
-            var joinedMetas = newPresence.metas.filter(function(m) {
+            var joinedMetas = newPresence.metas.filter(function (m) {
               return curRefs.indexOf(m.phx_ref) < 0;
             });
-            var leftMetas = currentPresence.metas.filter(function(m) {
+            var leftMetas = currentPresence.metas.filter(function (m) {
               return newRefs.indexOf(m.phx_ref) < 0;
             });
             if (joinedMetas.length > 0) {
@@ -1143,15 +1144,13 @@ define('phoenix', ['exports'], function(exports) {
           joins[key] = newPresence;
         }
       });
-      this.syncDiff(state, {
-        joins: joins,
-        leaves: leaves
-      }, onJoin, onLeave);
+      return this.syncDiff(state, { joins: joins, leaves: leaves }, onJoin, onLeave);
     },
-    syncDiff: function syncDiff(state, _ref2, onJoin, onLeave) {
+    syncDiff: function syncDiff(currentState, _ref2, onJoin, onLeave) {
       var joins = _ref2.joins;
       var leaves = _ref2.leaves;
 
+      var state = this.clone(currentState);
       if (!onJoin) {
         onJoin = function onJoin() {};
       }
@@ -1159,7 +1158,7 @@ define('phoenix', ['exports'], function(exports) {
         onLeave = function onLeave() {};
       }
 
-      this.map(joins, function(key, newPresence) {
+      this.map(joins, function (key, newPresence) {
         var currentPresence = state[key];
         state[key] = newPresence;
         if (currentPresence) {
@@ -1169,15 +1168,15 @@ define('phoenix', ['exports'], function(exports) {
         }
         onJoin(key, currentPresence, newPresence);
       });
-      this.map(leaves, function(key, leftPresence) {
+      this.map(leaves, function (key, leftPresence) {
         var currentPresence = state[key];
         if (!currentPresence) {
           return;
         }
-        var refsToRemove = leftPresence.metas.map(function(m) {
+        var refsToRemove = leftPresence.metas.map(function (m) {
           return m.phx_ref;
         });
-        currentPresence.metas = currentPresence.metas.filter(function(p) {
+        currentPresence.metas = currentPresence.metas.filter(function (p) {
           return refsToRemove.indexOf(p.phx_ref) < 0;
         });
         onLeave(key, currentPresence, leftPresence);
@@ -1185,6 +1184,7 @@ define('phoenix', ['exports'], function(exports) {
           delete state[key];
         }
       });
+      return state;
     },
     list: function list(presences, chooser) {
       if (!chooser) {
@@ -1193,7 +1193,7 @@ define('phoenix', ['exports'], function(exports) {
         };
       }
 
-      return this.map(presences, function(key, presence) {
+      return this.map(presences, function (key, presence) {
         return chooser(key, presence);
       });
     },
@@ -1201,7 +1201,7 @@ define('phoenix', ['exports'], function(exports) {
     // private
 
     map: function map(obj, func) {
-      return Object.getOwnPropertyNames(obj).map(function(key) {
+      return Object.getOwnPropertyNames(obj).map(function (key) {
         return func(key, obj[key]);
       });
     },
@@ -1224,7 +1224,7 @@ define('phoenix', ['exports'], function(exports) {
   //    reconnectTimer.scheduleTimeout() // fires after 1000
   //
 
-  var Timer = function() {
+  var Timer = function () {
     function Timer(callback, timerCalc) {
       _classCallCheck(this, Timer);
 
@@ -1235,7 +1235,7 @@ define('phoenix', ['exports'], function(exports) {
     }
 
     _createClass(Timer, [{
-      key: 'reset',
+      key: "reset",
       value: function reset() {
         this.tries = 0;
         clearTimeout(this.timer);
@@ -1244,13 +1244,13 @@ define('phoenix', ['exports'], function(exports) {
       // Cancels any previous scheduleTimeout and schedules callback
 
     }, {
-      key: 'scheduleTimeout',
+      key: "scheduleTimeout",
       value: function scheduleTimeout() {
         var _this13 = this;
 
         clearTimeout(this.timer);
 
-        this.timer = setTimeout(function() {
+        this.timer = setTimeout(function () {
           _this13.tries = _this13.tries + 1;
           _this13.callback();
         }, this.timerCalc(this.tries + 1));

--- a/vendor/phoenix.js
+++ b/vendor/phoenix.js
@@ -1,56 +1,24 @@
 define('phoenix', ['exports'], function(exports) {
-  'use strict';
+  "use strict";
 
-  Object.defineProperty(exports, '__esModule', {
+  var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+
+  var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+  Object.defineProperty(exports, "__esModule", {
     value: true
   });
 
-  var _typeof = typeof Symbol === 'function' && typeof Symbol.iterator === 'symbol' ? function(obj) {
-    return typeof obj;
-  } : function(obj) {
-    return obj && typeof Symbol === 'function' && obj.constructor === Symbol ? 'symbol' : typeof obj;
-  };
+  function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
 
-  var _createClass = function() {
-    function defineProperties(target, props) {
-      for (var i = 0; i < props.length; i++) {
-        var descriptor = props[i];
-        descriptor.enumerable = descriptor.enumerable || false;
-        descriptor.configurable = true;
-        if ('value' in descriptor) descriptor.writable = true;
-        Object.defineProperty(target, descriptor.key, descriptor);
-      }
-    }
-    return function(Constructor, protoProps, staticProps) {
-      if (protoProps) defineProperties(Constructor.prototype, protoProps);
-      if (staticProps) defineProperties(Constructor, staticProps);
-      return Constructor;
-    };
-  }();
-
-  function _toConsumableArray(arr) {
-    if (Array.isArray(arr)) {
-      for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) {
-        arr2[i] = arr[i];
-      }
-      return arr2;
-    } else {
-      return Array.from(arr);
-    }
-  }
-
-  function _classCallCheck(instance, Constructor) {
-    if (!(instance instanceof Constructor)) {
-      throw new TypeError('Cannot call a class as a function');
-    }
-  }
+  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
   // Phoenix Channels JavaScript client
   //
   // ## Socket Connection
   //
   // A single connection is established to the server and
-  // channels are mulitplexed over the connection.
+  // channels are multiplexed over the connection.
   // Connect to the server using the `Socket` class:
   //
   //     let socket = new Socket("/ws", {params: {userToken: "123"}})
@@ -70,7 +38,7 @@ define('phoenix', ['exports'], function(exports) {
   // events are listened for, messages are pushed to the server, and
   // the channel is joined with ok/error/timeout matches:
   //
-  //     let channel = socket.channel("rooms:123", {token: roomToken})
+  //     let channel = socket.channel("room:123", {token: roomToken})
   //     channel.on("new_msg", msg => console.log("Got message", msg) )
   //     $input.onEnter( e => {
   //       channel.push("new_msg", {body: e.target.val}, 10000)
@@ -93,6 +61,15 @@ define('phoenix', ['exports'], function(exports) {
   // Successful joins receive an "ok" status, while unsuccessful joins
   // receive "error".
   //
+  // ## Duplicate Join Subscriptions
+  //
+  // While the client may join any number of topics on any number of channels,
+  // the client may only hold a single subscription for each unique topic at any
+  // given time. When attempting to create a duplicate subscription,
+  // the server will close the existing channel, log a warning, and
+  // spawn a new channel for the topic. The client will have their
+  // `channel.onClose` callbacks fired for the existing channel, and the new
+  // channel join will have its receive hooks processed as normal.
   //
   // ## Pushing Messages
   //
@@ -123,7 +100,7 @@ define('phoenix', ['exports'], function(exports) {
   // ### onError hooks
   //
   // `onError` hooks are invoked if the socket connection drops, or the channel
-  // crashes on the server. In either case, a channel rejoin is attemtped
+  // crashes on the server. In either case, a channel rejoin is attempted
   // automatically in an exponential backoff manner.
   //
   // ### onClose hooks
@@ -165,7 +142,7 @@ define('phoenix', ['exports'], function(exports) {
   // they came online from:
   //
   //     let state = {}
-  //     Presence.syncState(state, stateFromServer)
+  //     state = Presence.syncState(state, stateFromServer)
   //     let listBy = (id, {metas: [first, ...rest]}) => {
   //       first.count = rest.length + 1 // count of this user's presences
   //       first.id = id
@@ -195,42 +172,38 @@ define('phoenix', ['exports'], function(exports) {
   //     let presences = {} // client's initial empty presence state
   //     // receive initial presence data from server, sent after join
   //     myChannel.on("presences", state => {
-  //       Presence.syncState(presences, state, onJoin, onLeave)
+  //       presences = Presence.syncState(presences, state, onJoin, onLeave)
   //       displayUsers(Presence.list(presences))
   //     })
   //     // receive "presence_diff" from server, containing join/leave events
   //     myChannel.on("presence_diff", diff => {
-  //       Presence.syncDiff(presences, diff, onJoin, onLeave)
+  //       presences = Presence.syncDiff(presences, diff, onJoin, onLeave)
   //       this.setState({users: Presence.list(room.presences, listBy)})
   //     })
   //
-  var VSN = '1.0.0';
-  var SOCKET_STATES = {
-    connecting: 0,
-    open: 1,
-    closing: 2,
-    closed: 3
-  };
+  var VSN = "1.0.0";
+  var SOCKET_STATES = { connecting: 0, open: 1, closing: 2, closed: 3 };
   var DEFAULT_TIMEOUT = 10000;
   var CHANNEL_STATES = {
-    closed: 'closed',
-    errored: 'errored',
-    joined: 'joined',
-    joining: 'joining'
+    closed: "closed",
+    errored: "errored",
+    joined: "joined",
+    joining: "joining",
+    leaving: "leaving"
   };
   var CHANNEL_EVENTS = {
-    close: 'phx_close',
-    error: 'phx_error',
-    join: 'phx_join',
-    reply: 'phx_reply',
-    leave: 'phx_leave'
+    close: "phx_close",
+    error: "phx_error",
+    join: "phx_join",
+    reply: "phx_reply",
+    leave: "phx_leave"
   };
   var TRANSPORTS = {
-    longpoll: 'longpoll',
-    websocket: 'websocket'
+    longpoll: "longpoll",
+    websocket: "websocket"
   };
 
-  var Push = function() {
+  var Push = function () {
 
     // Initializes the Push
     //
@@ -254,7 +227,7 @@ define('phoenix', ['exports'], function(exports) {
     }
 
     _createClass(Push, [{
-      key: 'resend',
+      key: "resend",
       value: function resend(timeout) {
         this.timeout = timeout;
         this.cancelRefEvent();
@@ -265,9 +238,9 @@ define('phoenix', ['exports'], function(exports) {
         this.send();
       }
     }, {
-      key: 'send',
+      key: "send",
       value: function send() {
-        if (this.hasReceived('timeout')) {
+        if (this.hasReceived("timeout")) {
           return;
         }
         this.startTimeout();
@@ -280,36 +253,33 @@ define('phoenix', ['exports'], function(exports) {
         });
       }
     }, {
-      key: 'receive',
+      key: "receive",
       value: function receive(status, callback) {
         if (this.hasReceived(status)) {
           callback(this.receivedResp.response);
         }
 
-        this.recHooks.push({
-          status: status,
-          callback: callback
-        });
+        this.recHooks.push({ status: status, callback: callback });
         return this;
       }
 
       // private
 
     }, {
-      key: 'matchReceive',
+      key: "matchReceive",
       value: function matchReceive(_ref) {
         var status = _ref.status;
         var response = _ref.response;
         var ref = _ref.ref;
 
-        this.recHooks.filter(function(h) {
+        this.recHooks.filter(function (h) {
           return h.status === status;
-        }).forEach(function(h) {
+        }).forEach(function (h) {
           return h.callback(response);
         });
       }
     }, {
-      key: 'cancelRefEvent',
+      key: "cancelRefEvent",
       value: function cancelRefEvent() {
         if (!this.refEvent) {
           return;
@@ -317,13 +287,13 @@ define('phoenix', ['exports'], function(exports) {
         this.channel.off(this.refEvent);
       }
     }, {
-      key: 'cancelTimeout',
+      key: "cancelTimeout",
       value: function cancelTimeout() {
         clearTimeout(this.timeoutTimer);
         this.timeoutTimer = null;
       }
     }, {
-      key: 'startTimeout',
+      key: "startTimeout",
       value: function startTimeout() {
         var _this = this;
 
@@ -333,36 +303,33 @@ define('phoenix', ['exports'], function(exports) {
         this.ref = this.channel.socket.makeRef();
         this.refEvent = this.channel.replyEventName(this.ref);
 
-        this.channel.on(this.refEvent, function(payload) {
+        this.channel.on(this.refEvent, function (payload) {
           _this.cancelRefEvent();
           _this.cancelTimeout();
           _this.receivedResp = payload;
           _this.matchReceive(payload);
         });
 
-        this.timeoutTimer = setTimeout(function() {
-          _this.trigger('timeout', {});
+        this.timeoutTimer = setTimeout(function () {
+          _this.trigger("timeout", {});
         }, this.timeout);
       }
     }, {
-      key: 'hasReceived',
+      key: "hasReceived",
       value: function hasReceived(status) {
         return this.receivedResp && this.receivedResp.status === status;
       }
     }, {
-      key: 'trigger',
+      key: "trigger",
       value: function trigger(status, response) {
-        this.channel.trigger(this.refEvent, {
-          status: status,
-          response: response
-        });
+        this.channel.trigger(this.refEvent, { status: status, response: response });
       }
     }]);
 
     return Push;
   }();
 
-  var Channel = exports.Channel = function() {
+  var Channel = exports.Channel = function () {
     function Channel(topic, params, socket) {
       var _this2 = this;
 
@@ -377,43 +344,46 @@ define('phoenix', ['exports'], function(exports) {
       this.joinedOnce = false;
       this.joinPush = new Push(this, CHANNEL_EVENTS.join, this.params, this.timeout);
       this.pushBuffer = [];
-      this.rejoinTimer = new Timer(function() {
+      this.rejoinTimer = new Timer(function () {
         return _this2.rejoinUntilConnected();
       }, this.socket.reconnectAfterMs);
-      this.joinPush.receive('ok', function() {
+      this.joinPush.receive("ok", function () {
         _this2.state = CHANNEL_STATES.joined;
         _this2.rejoinTimer.reset();
-        _this2.pushBuffer.forEach(function(pushEvent) {
+        _this2.pushBuffer.forEach(function (pushEvent) {
           return pushEvent.send();
         });
         _this2.pushBuffer = [];
       });
-      this.onClose(function() {
-        _this2.socket.log('channel', 'close ' + _this2.topic);
+      this.onClose(function () {
+        _this2.rejoinTimer.reset();
+        _this2.socket.log("channel", "close " + _this2.topic + " " + _this2.joinRef());
         _this2.state = CHANNEL_STATES.closed;
         _this2.socket.remove(_this2);
       });
-      this.onError(function(reason) {
-        _this2.socket.log('channel', 'error ' + _this2.topic, reason);
-        _this2.state = CHANNEL_STATES.errored;
-        _this2.rejoinTimer.scheduleTimeout();
-      });
-      this.joinPush.receive('timeout', function() {
-        if (_this2.state !== CHANNEL_STATES.joining) {
+      this.onError(function (reason) {
+        if (_this2.isLeaving() || _this2.isClosed()) {
           return;
         }
-
-        _this2.socket.log('channel', 'timeout ' + _this2.topic, _this2.joinPush.timeout);
+        _this2.socket.log("channel", "error " + _this2.topic, reason);
         _this2.state = CHANNEL_STATES.errored;
         _this2.rejoinTimer.scheduleTimeout();
       });
-      this.on(CHANNEL_EVENTS.reply, function(payload, ref) {
+      this.joinPush.receive("timeout", function () {
+        if (!_this2.isJoining()) {
+          return;
+        }
+        _this2.socket.log("channel", "timeout " + _this2.topic, _this2.joinPush.timeout);
+        _this2.state = CHANNEL_STATES.errored;
+        _this2.rejoinTimer.scheduleTimeout();
+      });
+      this.on(CHANNEL_EVENTS.reply, function (payload, ref) {
         _this2.trigger(_this2.replyEventName(ref), payload);
       });
     }
 
     _createClass(Channel, [{
-      key: 'rejoinUntilConnected',
+      key: "rejoinUntilConnected",
       value: function rejoinUntilConnected() {
         this.rejoinTimer.scheduleTimeout();
         if (this.socket.isConnected()) {
@@ -421,7 +391,7 @@ define('phoenix', ['exports'], function(exports) {
         }
       }
     }, {
-      key: 'join',
+      key: "join",
       value: function join() {
         var timeout = arguments.length <= 0 || arguments[0] === undefined ? this.timeout : arguments[0];
 
@@ -429,44 +399,41 @@ define('phoenix', ['exports'], function(exports) {
           throw "tried to join multiple times. 'join' can only be called a single time per channel instance";
         } else {
           this.joinedOnce = true;
+          this.rejoin(timeout);
+          return this.joinPush;
         }
-        this.rejoin(timeout);
-        return this.joinPush;
       }
     }, {
-      key: 'onClose',
+      key: "onClose",
       value: function onClose(callback) {
         this.on(CHANNEL_EVENTS.close, callback);
       }
     }, {
-      key: 'onError',
+      key: "onError",
       value: function onError(callback) {
-        this.on(CHANNEL_EVENTS.error, function(reason) {
+        this.on(CHANNEL_EVENTS.error, function (reason) {
           return callback(reason);
         });
       }
     }, {
-      key: 'on',
+      key: "on",
       value: function on(event, callback) {
-        this.bindings.push({
-          event: event,
-          callback: callback
-        });
+        this.bindings.push({ event: event, callback: callback });
       }
     }, {
-      key: 'off',
+      key: "off",
       value: function off(event) {
-        this.bindings = this.bindings.filter(function(bind) {
+        this.bindings = this.bindings.filter(function (bind) {
           return bind.event !== event;
         });
       }
     }, {
-      key: 'canPush',
+      key: "canPush",
       value: function canPush() {
-        return this.socket.isConnected() && this.state === CHANNEL_STATES.joined;
+        return this.socket.isConnected() && this.isJoined();
       }
     }, {
-      key: 'push',
+      key: "push",
       value: function push(event, payload) {
         var timeout = arguments.length <= 2 || arguments[2] === undefined ? this.timeout : arguments[2];
 
@@ -498,25 +465,26 @@ define('phoenix', ['exports'], function(exports) {
       //
 
     }, {
-      key: 'leave',
+      key: "leave",
       value: function leave() {
         var _this3 = this;
 
         var timeout = arguments.length <= 0 || arguments[0] === undefined ? this.timeout : arguments[0];
 
+        this.state = CHANNEL_STATES.leaving;
         var onClose = function onClose() {
-          _this3.socket.log('channel', 'leave ' + _this3.topic);
-          _this3.trigger(CHANNEL_EVENTS.close, 'leave');
+          _this3.socket.log("channel", "leave " + _this3.topic);
+          _this3.trigger(CHANNEL_EVENTS.close, "leave", _this3.joinRef());
         };
         var leavePush = new Push(this, CHANNEL_EVENTS.leave, {}, timeout);
-        leavePush.receive('ok', function() {
+        leavePush.receive("ok", function () {
           return onClose();
-        }).receive('timeout', function() {
+        }).receive("timeout", function () {
           return onClose();
         });
         leavePush.send();
         if (!this.canPush()) {
-          leavePush.trigger('ok', {});
+          leavePush.trigger("ok", {});
         }
 
         return leavePush;
@@ -525,51 +493,101 @@ define('phoenix', ['exports'], function(exports) {
       // Overridable message hook
       //
       // Receives all events for specialized message handling
+      // before dispatching to the channel callbacks.
+      //
+      // Must return the payload, modified or unmodified
 
     }, {
-      key: 'onMessage',
-      value: function onMessage(event, payload, ref) {}
+      key: "onMessage",
+      value: function onMessage(event, payload, ref) {
+        return payload;
+      }
 
       // private
 
     }, {
-      key: 'isMember',
+      key: "isMember",
       value: function isMember(topic) {
         return this.topic === topic;
       }
     }, {
-      key: 'sendJoin',
+      key: "joinRef",
+      value: function joinRef() {
+        return this.joinPush.ref;
+      }
+    }, {
+      key: "sendJoin",
       value: function sendJoin(timeout) {
         this.state = CHANNEL_STATES.joining;
         this.joinPush.resend(timeout);
       }
     }, {
-      key: 'rejoin',
+      key: "rejoin",
       value: function rejoin() {
         var timeout = arguments.length <= 0 || arguments[0] === undefined ? this.timeout : arguments[0];
+        if (this.isLeaving()) {
+          return;
+        }
         this.sendJoin(timeout);
       }
     }, {
-      key: 'trigger',
-      value: function trigger(triggerEvent, payload, ref) {
-        this.onMessage(triggerEvent, payload, ref);
-        this.bindings.filter(function(bind) {
-          return bind.event === triggerEvent;
-        }).map(function(bind) {
-          return bind.callback(payload, ref);
+      key: "trigger",
+      value: function trigger(event, payload, ref) {
+        var close = CHANNEL_EVENTS.close;
+        var error = CHANNEL_EVENTS.error;
+        var leave = CHANNEL_EVENTS.leave;
+        var join = CHANNEL_EVENTS.join;
+
+        if (ref && [close, error, leave, join].indexOf(event) >= 0 && ref !== this.joinRef()) {
+          return;
+        }
+        var handledPayload = this.onMessage(event, payload, ref);
+        if (payload && !handledPayload) {
+          throw "channel onMessage callbacks must return the payload, modified or unmodified";
+        }
+
+        this.bindings.filter(function (bind) {
+          return bind.event === event;
+        }).map(function (bind) {
+          return bind.callback(handledPayload, ref);
         });
       }
     }, {
-      key: 'replyEventName',
+      key: "replyEventName",
       value: function replyEventName(ref) {
-        return 'chan_reply_' + ref;
+        return "chan_reply_" + ref;
+      }
+    }, {
+      key: "isClosed",
+      value: function isClosed() {
+        return this.state === CHANNEL_STATES.closed;
+      }
+    }, {
+      key: "isErrored",
+      value: function isErrored() {
+        return this.state === CHANNEL_STATES.errored;
+      }
+    }, {
+      key: "isJoined",
+      value: function isJoined() {
+        return this.state === CHANNEL_STATES.joined;
+      }
+    }, {
+      key: "isJoining",
+      value: function isJoining() {
+        return this.state === CHANNEL_STATES.joining;
+      }
+    }, {
+      key: "isLeaving",
+      value: function isLeaving() {
+        return this.state === CHANNEL_STATES.leaving;
       }
     }]);
 
     return Channel;
   }();
 
-  var Socket = exports.Socket = function() {
+  var Socket = exports.Socket = function () {
 
     // Initializes the Socket
     //
@@ -607,59 +625,52 @@ define('phoenix', ['exports'], function(exports) {
 
       _classCallCheck(this, Socket);
 
-      this.stateChangeCallbacks = {
-        open: [],
-        close: [],
-        error: [],
-        message: []
-      };
+      this.stateChangeCallbacks = { open: [], close: [], error: [], message: [] };
       this.channels = [];
       this.sendBuffer = [];
       this.ref = 0;
       this.timeout = opts.timeout || DEFAULT_TIMEOUT;
       this.transport = opts.transport || window.WebSocket || LongPoll;
       this.heartbeatIntervalMs = opts.heartbeatIntervalMs || 30000;
-      this.reconnectAfterMs = opts.reconnectAfterMs || function(tries) {
-        return [1000, 2000, 5000, 10000][tries - 1] || 10000;
-      };
-      this.logger = opts.logger || function() {}; // noop
+      this.reconnectAfterMs = opts.reconnectAfterMs || function (tries) {
+          return [1000, 2000, 5000, 10000][tries - 1] || 10000;
+        };
+      this.logger = opts.logger || function () {}; // noop
       this.longpollerTimeout = opts.longpollerTimeout || 20000;
       this.params = opts.params || {};
-      this.endPoint = endPoint + '/' + TRANSPORTS.websocket;
-      this.reconnectTimer = new Timer(function() {
-        _this4.disconnect(function() {
+      this.endPoint = endPoint + "/" + TRANSPORTS.websocket;
+      this.reconnectTimer = new Timer(function () {
+        _this4.disconnect(function () {
           return _this4.connect();
         });
       }, this.reconnectAfterMs);
     }
 
     _createClass(Socket, [{
-      key: 'protocol',
+      key: "protocol",
       value: function protocol() {
-        return location.protocol.match(/^https/) ? 'wss' : 'ws';
+        return location.protocol.match(/^https/) ? "wss" : "ws";
       }
     }, {
-      key: 'endPointURL',
+      key: "endPointURL",
       value: function endPointURL() {
-        var uri = Ajax.appendParams(Ajax.appendParams(this.endPoint, this.params), {
-          vsn: VSN
-        });
-        if (uri.charAt(0) !== '/') {
+        var uri = Ajax.appendParams(Ajax.appendParams(this.endPoint, this.params), { vsn: VSN });
+        if (uri.charAt(0) !== "/") {
           return uri;
         }
-        if (uri.charAt(1) === '/') {
-          return this.protocol() + ':' + uri;
+        if (uri.charAt(1) === "/") {
+          return this.protocol() + ":" + uri;
         }
 
-        return this.protocol() + '://' + location.host + uri;
+        return this.protocol() + "://" + location.host + uri;
       }
     }, {
-      key: 'disconnect',
+      key: "disconnect",
       value: function disconnect(callback, code, reason) {
         if (this.conn) {
-          this.conn.onclose = function() {}; // noop
+          this.conn.onclose = function () {}; // noop
           if (code) {
-            this.conn.close(code, reason || '');
+            this.conn.close(code, reason || "");
           } else {
             this.conn.close();
           }
@@ -671,12 +682,12 @@ define('phoenix', ['exports'], function(exports) {
       // params - The params to send when connecting, for example `{user_id: userToken}`
 
     }, {
-      key: 'connect',
+      key: "connect",
       value: function connect(params) {
         var _this5 = this;
 
         if (params) {
-          console && console.log('passing params to connect is deprecated. Instead pass :params to the Socket constructor');
+          console && console.log("passing params to connect is deprecated. Instead pass :params to the Socket constructor");
           this.params = params;
         }
         if (this.conn) {
@@ -685,16 +696,16 @@ define('phoenix', ['exports'], function(exports) {
 
         this.conn = new this.transport(this.endPointURL());
         this.conn.timeout = this.longpollerTimeout;
-        this.conn.onopen = function() {
+        this.conn.onopen = function () {
           return _this5.onConnOpen();
         };
-        this.conn.onerror = function(error) {
+        this.conn.onerror = function (error) {
           return _this5.onConnError(error);
         };
-        this.conn.onmessage = function(event) {
+        this.conn.onmessage = function (event) {
           return _this5.onConnMessage(event);
         };
-        this.conn.onclose = function(event) {
+        this.conn.onclose = function (event) {
           return _this5.onConnClose(event);
         };
       }
@@ -702,7 +713,7 @@ define('phoenix', ['exports'], function(exports) {
       // Logs the message. Override `this.logger` for specialized logging. noops by default
 
     }, {
-      key: 'log',
+      key: "log",
       value: function log(kind, msg, data) {
         this.logger(kind, msg, data);
       }
@@ -715,98 +726,98 @@ define('phoenix', ['exports'], function(exports) {
       //
 
     }, {
-      key: 'onOpen',
+      key: "onOpen",
       value: function onOpen(callback) {
         this.stateChangeCallbacks.open.push(callback);
       }
     }, {
-      key: 'onClose',
+      key: "onClose",
       value: function onClose(callback) {
         this.stateChangeCallbacks.close.push(callback);
       }
     }, {
-      key: 'onError',
+      key: "onError",
       value: function onError(callback) {
         this.stateChangeCallbacks.error.push(callback);
       }
     }, {
-      key: 'onMessage',
+      key: "onMessage",
       value: function onMessage(callback) {
         this.stateChangeCallbacks.message.push(callback);
       }
     }, {
-      key: 'onConnOpen',
+      key: "onConnOpen",
       value: function onConnOpen() {
         var _this6 = this;
 
-        this.log('transport', 'connected to ' + this.endPointURL(), this.transport.prototype);
+        this.log("transport", "connected to " + this.endPointURL(), this.transport.prototype);
         this.flushSendBuffer();
         this.reconnectTimer.reset();
         if (!this.conn.skipHeartbeat) {
           clearInterval(this.heartbeatTimer);
-          this.heartbeatTimer = setInterval(function() {
+          this.heartbeatTimer = setInterval(function () {
             return _this6.sendHeartbeat();
           }, this.heartbeatIntervalMs);
         }
-        this.stateChangeCallbacks.open.forEach(function(callback) {
+        this.stateChangeCallbacks.open.forEach(function (callback) {
           return callback();
         });
       }
     }, {
-      key: 'onConnClose',
+      key: "onConnClose",
       value: function onConnClose(event) {
-        this.log('transport', 'close', event);
+        this.log("transport", "close", event);
         this.triggerChanError();
         clearInterval(this.heartbeatTimer);
         this.reconnectTimer.scheduleTimeout();
-        this.stateChangeCallbacks.close.forEach(function(callback) {
+        this.stateChangeCallbacks.close.forEach(function (callback) {
           return callback(event);
         });
       }
     }, {
-      key: 'onConnError',
+      key: "onConnError",
       value: function onConnError(error) {
-        this.log('transport', error);
+        this.log("transport", error);
         this.triggerChanError();
-        this.stateChangeCallbacks.error.forEach(function(callback) {
+        this.stateChangeCallbacks.error.forEach(function (callback) {
           return callback(error);
         });
       }
     }, {
-      key: 'triggerChanError',
+      key: "triggerChanError",
       value: function triggerChanError() {
-        this.channels.forEach(function(channel) {
+        this.channels.forEach(function (channel) {
           return channel.trigger(CHANNEL_EVENTS.error);
         });
       }
     }, {
-      key: 'connectionState',
+      key: "connectionState",
       value: function connectionState() {
         switch (this.conn && this.conn.readyState) {
           case SOCKET_STATES.connecting:
-            return 'connecting';
+            return "connecting";
           case SOCKET_STATES.open:
-            return 'open';
+            return "open";
           case SOCKET_STATES.closing:
-            return 'closing';
+            return "closing";
           default:
-            return 'closed';
+            return "closed";
         }
       }
     }, {
-      key: 'isConnected',
+      key: "isConnected",
       value: function isConnected() {
-        return this.connectionState() === 'open';
+        return this.connectionState() === "open";
       }
     }, {
-      key: 'remove',
+      key: "remove",
       value: function remove(channel) {
-        this.channels = this.channels.filter(function(c) {
-          return !c.isMember(channel.topic);
+        this.channels = this.channels.filter(function (c) {
+          return c.joinRef() !== channel.joinRef();
         });
       }
     }, {
-      key: 'channel',
+      key: "channel",
       value: function channel(topic) {
         var chanParams = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
 
@@ -815,7 +826,7 @@ define('phoenix', ['exports'], function(exports) {
         return chan;
       }
     }, {
-      key: 'push',
+      key: "push",
       value: function push(data) {
         var _this7 = this;
 
@@ -827,7 +838,7 @@ define('phoenix', ['exports'], function(exports) {
         var callback = function callback() {
           return _this7.conn.send(JSON.stringify(data));
         };
-        this.log('push', topic + ' ' + event + ' (' + ref + ')', payload);
+        this.log("push", topic + " " + event + " (" + ref + ")", payload);
         if (this.isConnected()) {
           callback();
         } else {
@@ -838,7 +849,7 @@ define('phoenix', ['exports'], function(exports) {
       // Return the next message ref, accounting for overflows
 
     }, {
-      key: 'makeRef',
+      key: "makeRef",
       value: function makeRef() {
         var newRef = this.ref + 1;
         if (newRef === this.ref) {
@@ -850,30 +861,25 @@ define('phoenix', ['exports'], function(exports) {
         return this.ref.toString();
       }
     }, {
-      key: 'sendHeartbeat',
+      key: "sendHeartbeat",
       value: function sendHeartbeat() {
         if (!this.isConnected()) {
           return;
         }
-        this.push({
-          topic: 'phoenix',
-          event: 'heartbeat',
-          payload: {},
-          ref: this.makeRef()
-        });
+        this.push({ topic: "phoenix", event: "heartbeat", payload: {}, ref: this.makeRef() });
       }
     }, {
-      key: 'flushSendBuffer',
+      key: "flushSendBuffer",
       value: function flushSendBuffer() {
         if (this.isConnected() && this.sendBuffer.length > 0) {
-          this.sendBuffer.forEach(function(callback) {
+          this.sendBuffer.forEach(function (callback) {
             return callback();
           });
           this.sendBuffer = [];
         }
       }
     }, {
-      key: 'onConnMessage',
+      key: "onConnMessage",
       value: function onConnMessage(rawMessage) {
         var msg = JSON.parse(rawMessage.data);
         var topic = msg.topic;
@@ -881,13 +887,13 @@ define('phoenix', ['exports'], function(exports) {
         var payload = msg.payload;
         var ref = msg.ref;
 
-        this.log('receive', (payload.status || '') + ' ' + topic + ' ' + event + ' ' + (ref && '(' + ref + ')' || ''), payload);
-        this.channels.filter(function(channel) {
+        this.log("receive", (payload.status || "") + " " + topic + " " + event + " " + (ref && "(" + ref + ")" || ""), payload);
+        this.channels.filter(function (channel) {
           return channel.isMember(topic);
-        }).forEach(function(channel) {
+        }).forEach(function (channel) {
           return channel.trigger(event, payload, ref);
         });
-        this.stateChangeCallbacks.message.forEach(function(callback) {
+        this.stateChangeCallbacks.message.forEach(function (callback) {
           return callback(msg);
         });
       }
@@ -896,17 +902,17 @@ define('phoenix', ['exports'], function(exports) {
     return Socket;
   }();
 
-  var LongPoll = exports.LongPoll = function() {
+  var LongPoll = exports.LongPoll = function () {
     function LongPoll(endPoint) {
       _classCallCheck(this, LongPoll);
 
       this.endPoint = null;
       this.token = null;
       this.skipHeartbeat = true;
-      this.onopen = function() {}; // noop
-      this.onerror = function() {}; // noop
-      this.onmessage = function() {}; // noop
-      this.onclose = function() {}; // noop
+      this.onopen = function () {}; // noop
+      this.onerror = function () {}; // noop
+      this.onmessage = function () {}; // noop
+      this.onclose = function () {}; // noop
       this.pollEndpoint = this.normalizeEndpoint(endPoint);
       this.readyState = SOCKET_STATES.connecting;
 
@@ -914,31 +920,29 @@ define('phoenix', ['exports'], function(exports) {
     }
 
     _createClass(LongPoll, [{
-      key: 'normalizeEndpoint',
+      key: "normalizeEndpoint",
       value: function normalizeEndpoint(endPoint) {
-        return endPoint.replace('ws://', 'http://').replace('wss://', 'https://').replace(new RegExp('(.*)\/' + TRANSPORTS.websocket), '$1/' + TRANSPORTS.longpoll);
+        return endPoint.replace("ws://", "http://").replace("wss://", "https://").replace(new RegExp("(.*)\/" + TRANSPORTS.websocket), "$1/" + TRANSPORTS.longpoll);
       }
     }, {
-      key: 'endpointURL',
+      key: "endpointURL",
       value: function endpointURL() {
-        return Ajax.appendParams(this.pollEndpoint, {
-          token: this.token
-        });
+        return Ajax.appendParams(this.pollEndpoint, { token: this.token });
       }
     }, {
-      key: 'closeAndRetry',
+      key: "closeAndRetry",
       value: function closeAndRetry() {
         this.close();
         this.readyState = SOCKET_STATES.connecting;
       }
     }, {
-      key: 'ontimeout',
+      key: "ontimeout",
       value: function ontimeout() {
-        this.onerror('timeout');
+        this.onerror("timeout");
         this.closeAndRetry();
       }
     }, {
-      key: 'poll',
+      key: "poll",
       value: function poll() {
         var _this8 = this;
 
@@ -946,7 +950,7 @@ define('phoenix', ['exports'], function(exports) {
           return;
         }
 
-        Ajax.request('GET', this.endpointURL(), 'application/json', null, this.timeout, this.ontimeout.bind(this), function(resp) {
+        Ajax.request("GET", this.endpointURL(), "application/json", null, this.timeout, this.ontimeout.bind(this), function (resp) {
           if (resp) {
             var status = resp.status;
             var token = resp.token;
@@ -959,10 +963,8 @@ define('phoenix', ['exports'], function(exports) {
 
           switch (status) {
             case 200:
-              messages.forEach(function(msg) {
-                return _this8.onmessage({
-                  data: JSON.stringify(msg)
-                });
+              messages.forEach(function (msg) {
+                return _this8.onmessage({ data: JSON.stringify(msg) });
               });
               _this8.poll();
               break;
@@ -980,16 +982,16 @@ define('phoenix', ['exports'], function(exports) {
               _this8.closeAndRetry();
               break;
             default:
-              throw 'unhandled poll status ' + status;
+              throw "unhandled poll status " + status;
           }
         });
       }
     }, {
-      key: 'send',
+      key: "send",
       value: function send(body) {
         var _this9 = this;
 
-        Ajax.request('POST', this.endpointURL(), 'application/json', body, this.timeout, this.onerror.bind(this, 'timeout'), function(resp) {
+        Ajax.request("POST", this.endpointURL(), "application/json", body, this.timeout, this.onerror.bind(this, "timeout"), function (resp) {
           if (!resp || resp.status !== 200) {
             _this9.onerror(status);
             _this9.closeAndRetry();
@@ -997,7 +999,7 @@ define('phoenix', ['exports'], function(exports) {
         });
       }
     }, {
-      key: 'close',
+      key: "close",
       value: function close(code, reason) {
         this.readyState = SOCKET_STATES.closed;
         this.onclose();
@@ -1007,31 +1009,31 @@ define('phoenix', ['exports'], function(exports) {
     return LongPoll;
   }();
 
-  var Ajax = exports.Ajax = function() {
+  var Ajax = exports.Ajax = function () {
     function Ajax() {
       _classCallCheck(this, Ajax);
     }
 
     _createClass(Ajax, null, [{
-      key: 'request',
+      key: "request",
       value: function request(method, endPoint, accept, body, timeout, ontimeout, callback) {
         if (window.XDomainRequest) {
           var req = new XDomainRequest(); // IE8, IE9
           this.xdomainRequest(req, method, endPoint, body, timeout, ontimeout, callback);
         } else {
-          var _req = window.XMLHttpRequest ? new XMLHttpRequest() : // IE7+, Firefox, Chrome, Opera, Safari
-            new ActiveXObject('Microsoft.XMLHTTP'); // IE6, IE5
-          this.xhrRequest(_req, method, endPoint, accept, body, timeout, ontimeout, callback);
+          var req = window.XMLHttpRequest ? new XMLHttpRequest() : // IE7+, Firefox, Chrome, Opera, Safari
+            new ActiveXObject("Microsoft.XMLHTTP"); // IE6, IE5
+          this.xhrRequest(req, method, endPoint, accept, body, timeout, ontimeout, callback);
         }
       }
     }, {
-      key: 'xdomainRequest',
+      key: "xdomainRequest",
       value: function xdomainRequest(req, method, endPoint, body, timeout, ontimeout, callback) {
         var _this10 = this;
 
         req.timeout = timeout;
         req.open(method, endPoint);
-        req.onload = function() {
+        req.onload = function () {
           var response = _this10.parseJSON(req.responseText);
           callback && callback(response);
         };
@@ -1040,22 +1042,22 @@ define('phoenix', ['exports'], function(exports) {
         }
 
         // Work around bug in IE9 that requires an attached onprogress handler
-        req.onprogress = function() {};
+        req.onprogress = function () {};
 
         req.send(body);
       }
     }, {
-      key: 'xhrRequest',
+      key: "xhrRequest",
       value: function xhrRequest(req, method, endPoint, accept, body, timeout, ontimeout, callback) {
         var _this11 = this;
 
         req.timeout = timeout;
         req.open(method, endPoint, true);
-        req.setRequestHeader('Content-Type', accept);
-        req.onerror = function() {
+        req.setRequestHeader("Content-Type", accept);
+        req.onerror = function () {
           callback && callback(null);
         };
-        req.onreadystatechange = function() {
+        req.onreadystatechange = function () {
           if (req.readyState === _this11.states.complete && callback) {
             var response = _this11.parseJSON(req.responseText);
             callback(response);
@@ -1068,73 +1070,72 @@ define('phoenix', ['exports'], function(exports) {
         req.send(body);
       }
     }, {
-      key: 'parseJSON',
+      key: "parseJSON",
       value: function parseJSON(resp) {
-        return resp && resp !== '' ? JSON.parse(resp) : null;
+        return resp && resp !== "" ? JSON.parse(resp) : null;
       }
     }, {
-      key: 'serialize',
+      key: "serialize",
       value: function serialize(obj, parentKey) {
         var queryStr = [];
         for (var key in obj) {
           if (!obj.hasOwnProperty(key)) {
             continue;
           }
-          var paramKey = parentKey ? parentKey + '[' + key + ']' : key;
+          var paramKey = parentKey ? parentKey + "[" + key + "]" : key;
           var paramVal = obj[key];
-          if ((typeof paramVal === 'undefined' ? 'undefined' : _typeof(paramVal)) === 'object') {
+          if ((typeof paramVal === "undefined" ? "undefined" : _typeof(paramVal)) === "object") {
             queryStr.push(this.serialize(paramVal, paramKey));
           } else {
-            queryStr.push(encodeURIComponent(paramKey) + '=' + encodeURIComponent(paramVal));
+            queryStr.push(encodeURIComponent(paramKey) + "=" + encodeURIComponent(paramVal));
           }
         }
-        return queryStr.join('&');
+        return queryStr.join("&");
       }
     }, {
-      key: 'appendParams',
+      key: "appendParams",
       value: function appendParams(url, params) {
         if (Object.keys(params).length === 0) {
           return url;
         }
 
-        var prefix = url.match(/\?/) ? '&' : '?';
-        return '' + url + prefix + this.serialize(params);
+        var prefix = url.match(/\?/) ? "&" : "?";
+        return "" + url + prefix + this.serialize(params);
       }
     }]);
 
     return Ajax;
   }();
 
-  Ajax.states = {
-    complete: 4
-  };
+  Ajax.states = { complete: 4 };
 
   var Presence = exports.Presence = {
-    syncState: function syncState(state, newState, onJoin, onLeave) {
+    syncState: function syncState(currentState, newState, onJoin, onLeave) {
       var _this12 = this;
 
+      var state = this.clone(currentState);
       var joins = {};
       var leaves = {};
 
-      this.map(state, function(key, presence) {
+      this.map(state, function (key, presence) {
         if (!newState[key]) {
-          leaves[key] = _this12.clone(presence);
+          leaves[key] = presence;
         }
       });
-      this.map(newState, function(key, newPresence) {
+      this.map(newState, function (key, newPresence) {
         var currentPresence = state[key];
         if (currentPresence) {
-          (function() {
-            var newRefs = newPresence.metas.map(function(m) {
+          (function () {
+            var newRefs = newPresence.metas.map(function (m) {
               return m.phx_ref;
             });
-            var curRefs = currentPresence.metas.map(function(m) {
+            var curRefs = currentPresence.metas.map(function (m) {
               return m.phx_ref;
             });
-            var joinedMetas = newPresence.metas.filter(function(m) {
+            var joinedMetas = newPresence.metas.filter(function (m) {
               return curRefs.indexOf(m.phx_ref) < 0;
             });
-            var leftMetas = currentPresence.metas.filter(function(m) {
+            var leftMetas = currentPresence.metas.filter(function (m) {
               return newRefs.indexOf(m.phx_ref) < 0;
             });
             if (joinedMetas.length > 0) {
@@ -1150,15 +1151,13 @@ define('phoenix', ['exports'], function(exports) {
           joins[key] = newPresence;
         }
       });
-      this.syncDiff(state, {
-        joins: joins,
-        leaves: leaves
-      }, onJoin, onLeave);
+      return this.syncDiff(state, { joins: joins, leaves: leaves }, onJoin, onLeave);
     },
-    syncDiff: function syncDiff(state, _ref2, onJoin, onLeave) {
+    syncDiff: function syncDiff(currentState, _ref2, onJoin, onLeave) {
       var joins = _ref2.joins;
       var leaves = _ref2.leaves;
 
+      var state = this.clone(currentState);
       if (!onJoin) {
         onJoin = function onJoin() {};
       }
@@ -1166,7 +1165,7 @@ define('phoenix', ['exports'], function(exports) {
         onLeave = function onLeave() {};
       }
 
-      this.map(joins, function(key, newPresence) {
+      this.map(joins, function (key, newPresence) {
         var currentPresence = state[key];
         state[key] = newPresence;
         if (currentPresence) {
@@ -1176,15 +1175,15 @@ define('phoenix', ['exports'], function(exports) {
         }
         onJoin(key, currentPresence, newPresence);
       });
-      this.map(leaves, function(key, leftPresence) {
+      this.map(leaves, function (key, leftPresence) {
         var currentPresence = state[key];
         if (!currentPresence) {
           return;
         }
-        var refsToRemove = leftPresence.metas.map(function(m) {
+        var refsToRemove = leftPresence.metas.map(function (m) {
           return m.phx_ref;
         });
-        currentPresence.metas = currentPresence.metas.filter(function(p) {
+        currentPresence.metas = currentPresence.metas.filter(function (p) {
           return refsToRemove.indexOf(p.phx_ref) < 0;
         });
         onLeave(key, currentPresence, leftPresence);
@@ -1192,6 +1191,7 @@ define('phoenix', ['exports'], function(exports) {
           delete state[key];
         }
       });
+      return state;
     },
     list: function list(presences, chooser) {
       if (!chooser) {
@@ -1200,7 +1200,7 @@ define('phoenix', ['exports'], function(exports) {
         };
       }
 
-      return this.map(presences, function(key, presence) {
+      return this.map(presences, function (key, presence) {
         return chooser(key, presence);
       });
     },
@@ -1208,7 +1208,7 @@ define('phoenix', ['exports'], function(exports) {
     // private
 
     map: function map(obj, func) {
-      return Object.getOwnPropertyNames(obj).map(function(key) {
+      return Object.getOwnPropertyNames(obj).map(function (key) {
         return func(key, obj[key]);
       });
     },
@@ -1217,21 +1217,21 @@ define('phoenix', ['exports'], function(exports) {
     }
   };
 
-  // Creates a timer that accepts a `timerCalc` function to perform
-  // calculated timeout retries, such as exponential backoff.
-  //
-  // ## Examples
-  //
-  //    let reconnectTimer = new Timer(() => this.connect(), function(tries){
-  //      return [1000, 5000, 10000][tries - 1] || 10000
-  //    })
-  //    reconnectTimer.scheduleTimeout() // fires after 1000
-  //    reconnectTimer.scheduleTimeout() // fires after 5000
-  //    reconnectTimer.reset()
-  //    reconnectTimer.scheduleTimeout() // fires after 1000
-  //
+// Creates a timer that accepts a `timerCalc` function to perform
+// calculated timeout retries, such as exponential backoff.
+//
+// ## Examples
+//
+//    let reconnectTimer = new Timer(() => this.connect(), function(tries){
+//      return [1000, 5000, 10000][tries - 1] || 10000
+//    })
+//    reconnectTimer.scheduleTimeout() // fires after 1000
+//    reconnectTimer.scheduleTimeout() // fires after 5000
+//    reconnectTimer.reset()
+//    reconnectTimer.scheduleTimeout() // fires after 1000
+//
 
-  var Timer = function() {
+  var Timer = function () {
     function Timer(callback, timerCalc) {
       _classCallCheck(this, Timer);
 
@@ -1242,7 +1242,7 @@ define('phoenix', ['exports'], function(exports) {
     }
 
     _createClass(Timer, [{
-      key: 'reset',
+      key: "reset",
       value: function reset() {
         this.tries = 0;
         clearTimeout(this.timer);
@@ -1251,13 +1251,13 @@ define('phoenix', ['exports'], function(exports) {
       // Cancels any previous scheduleTimeout and schedules callback
 
     }, {
-      key: 'scheduleTimeout',
+      key: "scheduleTimeout",
       value: function scheduleTimeout() {
         var _this13 = this;
 
         clearTimeout(this.timer);
 
-        this.timer = setTimeout(function() {
+        this.timer = setTimeout(function () {
           _this13.tries = _this13.tries + 1;
           _this13.callback();
         }, this.timerCalc(this.tries + 1));


### PR DESCRIPTION
Hi there,

I copied the contents from phoenix.js to both files, removed the `window.XDomainRequest` references in `phoenix-stub.js` (as before).
The code style (e.g. using `"` vs. `'`) is now the same as in the original `phoenix.js`, which should make it easier to update to newer Phoenix versions in the future.
`ember test` and `npm test` run successfully.

Cheers, Arno