### PR TITLE
Bridge channel join events to the phoenix service 'join' event.

### DIFF
--- a/addon/services/phoenix-socket.js
+++ b/addon/services/phoenix-socket.js
@@ -39,7 +39,10 @@ export default Service.extend(Evented, {
     assert('must connect to a socket first', socket);
 
     const channel = socket.channel(name, params);
-    channel.join();
+    channel.join()
+      .receive("ok", (msg) => this.trigger('join', 'ok', name, msg))
+      .receive("error", (msg) => this.trigger('join', 'error', name, msg))
+      .receive("timeout", () => this.trigger('join', 'timeout', name));
     return channel;
   }
 });


### PR DESCRIPTION
Hi there,

I found it useful to bridge the channel join events to the phoenix service since those were left out and I wasn't able to chain the `receive` method to the returned `channel` object obtained from `joinChannel`.

Would be great to include this, otherwise, please let me know if it needs doing in a different way.

Thanks!